### PR TITLE
Update cuda_myriadgroestl.cu

### DIFF
--- a/cuda_myriadgroestl.cu
+++ b/cuda_myriadgroestl.cu
@@ -8,7 +8,7 @@
 // globaler Speicher für alle HeftyHashes aller Threads
 __constant__ uint32_t pTarget[8]; // Single GPU
 uint32_t *d_outputHashes[8];
-uint2 *d_resultNonce[8];
+extern uint2 *d_resultNonce[8];
 
 __constant__ uint32_t myriadgroestl_gpu_msg[32];
 


### PR DESCRIPTION
uint2 *d_resultNonce[8]; is already defined in Algo256/cuda_fugue256.cu, which causes a compile (Ubuntu 14.04) error:
cuda_myriadgroestl.o:(.bss+0x40): multiple definition of `d_resultNonce'
Algo256/cuda_fugue256.o:(.bss+0x40): first defined here
collect2: error: ld returned 1 exit status

adding "extern" fixes the compile error.