### PR TITLE
Update ccminer.cpp for compiling in Linux

### DIFF
--- a/ccminer.cpp
+++ b/ccminer.cpp
@@ -2228,10 +2228,10 @@ int main(int argc, char *argv[])
 	signal(SIGINT, signal_handler);
 #else
 	SetConsoleCtrlHandler((PHANDLER_ROUTINE)ConsoleHandler, TRUE);
-#endif
 
 	SetPriorityClass(NULL, HIGH_PRIORITY_CLASS);
 	SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS);
+#endif
 
 	if (active_gpus == 0) {
 		applog(LOG_ERR, "No CUDA devices found! terminating.");


### PR DESCRIPTION
Believe "SetPriorityClass" is Windows only.  Added it to the if statement above (similar to tpruvot's placement), though I guess a new if statement could be created for it too.  This fixes a compiling error in Linux (Ubuntu 14.04)