### PR TITLE
time-limit: hashing and benchmark

### DIFF
--- a/log.c
+++ b/log.c
@@ -48,97 +48,45 @@ void applog(int prio, const char *fmt, ...)
 #endif
 	else {
 		const char* color = "";
-		const char* hdr_fmt = NULL;
-		char* hdr     = NULL;
-		int   hdr_len = 0;
+		char *f;
+		int len;
 		struct tm tm;
 		time_t now = time(NULL);
-		int    tid = 0;
 
 		localtime_r(&now, &tm);
-		
-		if (use_colors) {
-			switch (prio) {
-				case LOG_ERR:     color = CL_RED; break;
-				case LOG_WARNING: color = CL_YLW; break;
-				case LOG_NOTICE:  color = CL_WHT; break;
-				case LOG_INFO:    color = ""; break;
-				case LOG_DEBUG:   color = CL_GRY; break;
 
-				case LOG_BLUE:
-					prio = LOG_NOTICE;
-					color = CL_CYN;
-					break;
-			}
-		} else if (prio == LOG_BLUE) {
-			prio = LOG_NOTICE;
+		switch (prio) {
+			case LOG_ERR:     color = CL_RED; break;
+			case LOG_WARNING: color = CL_YLW; break;
+			case LOG_NOTICE:  color = CL_WHT; break;
+			case LOG_INFO:    color = ""; break;
+			case LOG_DEBUG:   color = CL_GRY; break;
+
+			case LOG_BLUE:
+				prio = LOG_NOTICE;
+				color = CL_CYN;
+				break;
 		}
+		if (!use_colors)
+			color = "";
 
-#define HDR_TS_FMT	"[%d-%02d-%02d %02d:%02d:%02d] "
-#define HDR_TID_FMT	"tid(%#010x) "
-#define HDR_NO_TID_FMT	"%0.0d"
-#define HDR_COL_FMT	"%s"
-
-		if (opt_debug)
-		{
-			tid	= gettid();
-			hdr_fmt	= HDR_TS_FMT HDR_TID_FMT HDR_COL_FMT;
-		}
-		else
-			hdr_fmt = HDR_TS_FMT HDR_NO_TID_FMT HDR_COL_FMT;
-
-		hdr_len = snprintf(hdr, hdr_len, hdr_fmt,
+		len = 40 + (int) strlen(fmt) + 2;
+		f = (char*) alloca(len);
+		sprintf(f, "[%d-%02d-%02d %02d:%02d:%02d]%s %s%s\n",
 			tm.tm_year + 1900,
 			tm.tm_mon + 1,
 			tm.tm_mday,
 			tm.tm_hour,
 			tm.tm_min,
 			tm.tm_sec,
-			tid,
-			color);
-
-		if (hdr_len > 0) {
-			hdr_len += 1; /* Make room for NUL terminal */
-			if (NULL != (hdr = alloca(hdr_len * sizeof(char)))) {
-				char* msg     = NULL;
-				int   msg_len = 0;
-				va_list ap2;
-
-				va_copy(ap2, ap);
-				msg_len = vsnprintf(msg, msg_len, fmt, ap2);
-				va_end(ap2);
-
-				if (msg_len > 0) {
-					msg_len += 1; /* Make room for NUL terminal */
-
-					if (NULL != (msg = alloca(msg_len * sizeof(char)))) {
-						const char* eol = "\n";
-
-						if (use_colors)
-							eol = CL_N "\n";
-
-						snprintf(hdr, hdr_len, hdr_fmt,
-							tm.tm_year + 1900,
-							tm.tm_mon + 1,
-							tm.tm_mday,
-							tm.tm_hour,
-							tm.tm_min,
-							tm.tm_sec,
-							tid,
-							color);
-						vsnprintf(msg, msg_len, fmt, ap);
-
-						pthread_mutex_lock(&applog_lock);
-						fputs(hdr, stderr);
-						fputs(msg, stderr);
-						fputs(eol, stderr);
-						pthread_mutex_unlock(&applog_lock);
-
-						fflush(stderr);
-					}
-				}
-			}
-		}
+			color,
+			fmt,
+			use_colors ? CL_N : ""
+		);
+		pthread_mutex_lock(&applog_lock);
+		vfprintf(stdout, f, ap);	/* atomic write to stdout */
+		fflush(stdout);
+		pthread_mutex_unlock(&applog_lock);
 	}
 	va_end(ap);
 }

--- a/miner.h
+++ b/miner.h
@@ -517,6 +517,8 @@ extern int device_map[MAX_GPUS];
 extern long  device_sm[MAX_GPUS];
 extern uint32_t gpus_intensity[MAX_GPUS];
 
+extern void format_hashrate(double hashrate, char *output);
+extern void applog(int prio, const char *fmt, ...);
 extern json_t *json_rpc_call(CURL *curl, const char *url, const char *userpass,
 	const char *rpc_req, bool, bool, int *);
 extern void cbin2hex(char *out, const char *in, size_t len);

--- a/util.cpp
+++ b/util.cpp
@@ -68,6 +68,60 @@ struct thread_q {
 	pthread_cond_t		cond;
 };
 
+void format_hashrate(double hashrate, char *output)
+{
+	char prefix;
+
+	if (hashrate < 1e3)
+		prefix = ' ';
+	else if (hashrate < 1e6)
+	{
+		prefix = 'k';
+		hashrate *= 1e-3;
+	}
+	else if (hashrate < 1e9)
+	{
+		prefix = 'M';
+		hashrate *= 1e-6;
+	}
+	else if (hashrate < 1e12)
+	{
+		prefix = 'G';
+		hashrate *= 1e-9;
+	}
+	else if (hashrate < 1e15)
+	{
+		prefix = 'T';
+		hashrate *= 1e-12;
+	}
+	else if (hashrate < 1e18)
+	{
+		prefix = 'P';
+		hashrate *= 1e-15;
+	}
+	else if (hashrate < 1e21)
+	{
+		prefix = 'E';
+		hashrate *= 1e-18;
+	}
+	else if (hashrate < 1e24)
+	{
+		prefix = 'Z';
+		hashrate *= 1e-21;
+	}
+	else
+	{
+		prefix = 'Y';
+		hashrate *= 1e-24;
+	}
+
+	sprintf(
+		output,
+		prefix == ' ' ? "%.0f%cH/s" : "%.2f %cH/s",
+		hashrate, prefix
+	);
+}
+
 static void databuf_free(struct data_buffer *db)
 {
 	if (!db)


### PR DESCRIPTION
Time-limit [seconds] option, and benchmark results with a time-limit.  From Tpruvot fork.

Benchmarking Command line: ccminer -a quark --benchmark --time-limit 30 2>result.txt