### PR TITLE
NVML working in Linux

### DIFF
--- a/ccminer.cpp
+++ b/ccminer.cpp
@@ -432,7 +432,7 @@ static void affine_to_cpu_mask(int id, uint8_t mask) {
 	CPU_ZERO(&set);
 	for (uint8_t i = 0; i < num_cpus; i++) {
 		// cpu mask
-		if (mask & (1<<i)) { CPU_SET(i, &set); printf("%d \n", i); }
+		if (mask & (1<<i)) { CPU_SET(i, &set); }
 	}
 	if (id == -1) {
 		// process affinity
@@ -488,10 +488,8 @@ void proper_exit(int reason)
 
 	if (reason != CCEXIT_SIG) {
 #ifdef USE_WRAPNVML
-		#ifndef WIN32
-			if (hnvml)
-				nvml_destroy(hnvml);
-		#endif
+		if (hnvml)
+			nvml_destroy(hnvml);
 #endif
 
 		free(opt_syslog_pfx);


### PR DESCRIPTION
Fix: NVML works in Linux (Ubuntu 14.04).
Fix: an extra print of cpu mask (which revealed itself after the NVML fix)