### PR TITLE
Reinstate network_fail_flag

### DIFF
--- a/ccminer.cpp
+++ b/ccminer.cpp
@@ -1401,7 +1401,7 @@ static void *miner_thread(void *userdata)
 		pthread_mutex_unlock(&g_work_lock);
 
 		/* prevent gpu scans before a job is received */
-		if (have_stratum && work.data[0] == 0 && !opt_benchmark)
+		if ((have_stratum && work.data[0] == 0 || network_fail_flag) && !opt_benchmark)
 		{
 			sleep(1);
 			continue;	


### PR DESCRIPTION
Taken out as fix for solo mining, but was unrelated.